### PR TITLE
[#15] 댓글(reply) 구현

### DIFF
--- a/front/src/views/ReadView.vue
+++ b/front/src/views/ReadView.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 
-import {onMounted, ref} from "vue";
+import {onMounted, ref, computed} from "vue";
 import axios from "axios";
-import {ElButton} from "element-plus";
+import {ElButton, ElMessage, ElPagination} from "element-plus";
 import {useRoute, useRouter} from "vue-router";
+import { formatDistanceToNow } from "date-fns";
+import {ko} from "date-fns/locale/ko";
+import 'element-plus/dist/index.css';
 
 const props = defineProps({
   postId: {
@@ -21,8 +24,21 @@ const post = ref({
   files: [] as { fileName: string; downloadUrl: string; isAvailable: boolean }[], // 첨부파일 배열 추가
 })
 
+const comments = ref([] as any[]); // 댓글 목록
+const commentCount = ref(0); // 전체 댓글 수
+const newComment = ref(""); // 새 댓글
+
+// 페이지네이션 관련 상태
+const currentPage = ref(1);
+const pageSize = ref(10);
+
 const route = useRoute();
 const router = useRouter();
+
+// 상대 시간 계산 함수 (예: "3분 전")
+const relativeTime = (dateStr: string) => {
+  return formatDistanceToNow(new Date(dateStr), { addSuffix: true, locale: ko });
+};
 
 const moveToEdit = () =>{
   router.push({name: "edit", params: {postId: props.postId}});
@@ -43,7 +59,94 @@ onMounted(() => {
       })),
     };
   });
+  fetchComments();
 });
+
+// 댓글 목록 조회
+const fetchComments = () => {
+  // 예시: 페이지 1, 사이즈 10으로 조회 (필요에 따라 변경)
+  axios
+  .get("/api/comments", {
+    params: { postId: props.postId, page: currentPage.value, size: pageSize.value  },
+  })
+  .then((response) => {
+    const data = response.data.data;
+    comments.value = data.comment; // CommentPageResponse.comment 배열
+    commentCount.value = data.commentCount;
+  })
+  .catch((error) => {
+    console.error("댓글 불러오기 실패:", error);
+  });
+};
+
+/**
+ * 루트 댓글: 자신의 id와 parentCommentId가 같은 댓글
+ */
+const rootComments = computed(() => {
+  return comments.value.filter(
+    (c) => Number(c.id) === Number(c.parentCommentId)
+  );
+});
+
+/**
+ * 특정 댓글의 답글(대댓글) 가져오기
+ */
+const getReplies = (commentId: number | string) => {
+  return comments.value.filter(
+    (c) =>
+      Number(c.parentCommentId) === Number(commentId) &&
+      Number(c.id) !== Number(commentId)
+  );
+};
+
+const handlePageChange = (page: number) => {
+  currentPage.value = page;
+  fetchComments();
+};
+
+// 댓글 작성 API 호출
+const postComment = (parentId: number | null, content: string) => {
+  if (!content.trim()) {
+    ElMessage.error("댓글 내용을 입력해 주세요.");
+    return;
+  }
+  // 예시: nickname과 writerId는 고정값 (추후 로그인 정보로 대체)
+  const payload = {
+    postId: props.postId,
+    nickname: "익명",
+    content: content,
+    parentCommentId: parentId, // 여기서 부모 댓글의 id가 전달됨.
+    writerId: 1,
+  };
+
+  axios
+  .post("/api/comments", payload)
+  .then((response) => {
+    ElMessage.success("댓글이 등록되었습니다.");
+    // 루트 댓글의 경우 newComment 초기화, 답글의 경우 해당 입력값 초기화
+    if (parentId === null) {
+      newComment.value = "";
+    }
+    fetchComments();
+  })
+  .catch((error) => {
+    console.error("댓글 등록 실패:", error);
+    ElMessage.error("댓글 등록에 실패했습니다.");
+  });
+};
+
+const deleteComment = (commentId: number) => {
+  axios
+  .delete(`/api/comments/${commentId}`)
+  .then(() => {
+    ElMessage.success("댓글이 삭제되었습니다.");
+    fetchComments();
+  })
+  .catch((error) => {
+    console.error("댓글 삭제 실패:", error);
+    ElMessage.error("댓글 삭제에 실패했습니다.");
+  });
+};
 
 // 첨부파일 다운로드
 const downloadFile = (url: string, fileName: string, fileIndex: number) => {
@@ -122,6 +225,103 @@ const downloadFile = (url: string, fileName: string, fileIndex: number) => {
     </el-tag>
   </div>
 
+  <!-- 댓글 목록 -->
+  <div class="comments mt-3">
+    <h3>댓글 ({{ commentCount }})</h3>
+    <ul>
+      <li v-for="root in rootComments" :key="root.id" class="comment-item">
+        <!-- 루트 댓글 -->
+        <div class="comment-header">
+          <strong>{{ root.nickname }}</strong>
+          <span class="comment-time">({{ relativeTime(root.createdAt) }})</span>
+          <el-button
+            type="text"
+            size="small"
+            @click="deleteComment(root.id)"
+          >
+            삭제
+          </el-button>
+        </div>
+        <div class="comment-content" :class="{ deleted: root.deleted }">
+          <template v-if="root.deleted">
+            삭제된 댓글입니다
+          </template>
+          <template v-else>
+            {{ root.comment }}
+          </template>
+        </div>
+        <!-- 답글 버튼 및 입력폼 -->
+        <el-button
+          type="text"
+          size="small"
+          @click="root.showReply = !root.showReply"
+        >
+          답글
+        </el-button>
+        <div v-if="root.showReply" class="reply-input">
+          <el-input
+            type="textarea"
+            v-model="root.replyText"
+            placeholder="답글을 입력하세요."
+            rows="2"
+          />
+          <el-button
+            type="primary"
+            size="small"
+            @click="postComment(root.id, root.replyText)"
+          >
+            등록
+          </el-button>
+        </div>
+        <!-- 대댓글 목록 -->
+        <ul class="replies" v-if="getReplies(root.id).length">
+          <li v-for="reply in getReplies(root.id)" :key="reply.id" class="reply-item">
+            <div class="comment-header">
+              <strong>{{ reply.nickname }}</strong>
+              <span class="comment-time">({{ relativeTime(reply.createdAt) }})</span>
+              <el-button type="text" size="small" @click="deleteComment(reply.id)">
+                삭제
+              </el-button>
+            </div>
+            <div class="comment-content" :class="{ deleted: reply.deleted }">
+              <template v-if="reply.deleted">
+                삭제된 댓글입니다
+              </template>
+              <template v-else>
+                {{ reply.comment }}
+              </template>
+            </div>
+          </li>
+        </ul>
+        <hr class="comment-divider" />
+      </li>
+    </ul>
+    <!-- 페이지네이션 (댓글이 10개 이상일 경우) -->
+    <el-pagination
+      v-if="commentCount >= pageSize"
+      background
+      layout="prev, pager, next"
+      :page-size="pageSize"
+      :total="commentCount"
+      :current-page="currentPage"
+      @current-change="handlePageChange"
+    />
+  </div>
+
+  <!-- 루트 댓글 작성 폼 -->
+  <div class="new-comment mt-3">
+    <el-input
+      type="textarea"
+      v-model="newComment"
+      placeholder="댓글을 입력하세요."
+      rows="3"
+    />
+    <el-button type="primary" class="mt-2" @click="postComment(null, newComment)">
+      댓글 등록
+    </el-button>
+  </div>
+
+
   <div class="d-flex justify-content-end">
     <el-button type="primary" @click="moveToHome">목록으로</el-button>
     <el-button type="warning" @click="moveToEdit">수정</el-button>
@@ -164,4 +364,66 @@ const downloadFile = (url: string, fileName: string, fileIndex: number) => {
 .attachments li {
   margin-bottom: 4px;
 }
+
+/* 댓글 목록 스타일 */
+.comments {
+  margin-top: 20px;
+}
+
+.comments h3 {
+  margin-bottom: 8px;
+}
+
+.comment-item {
+  padding: 12px 0;
+}
+
+.comment-header {
+  font-size: 0.9rem;
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.comment-time {
+  color: #888;
+  font-size: 0.8rem;
+}
+
+.comment-content {
+  font-size: 1rem;
+  line-height: 1.4;
+  margin-bottom: 8px;
+}
+
+.comment-divider {
+  border: none;
+  border-top: 1px solid #ddd;
+  margin: 0;
+}
+
+/* 답글 입력폼 */
+.reply-input {
+  margin: 8px 0;
+}
+
+/* 대댓글(답글) 스타일 */
+.replies {
+  margin-left: 20px;
+  list-style-type: none;
+  padding: 0;
+}
+
+.reply-item {
+  padding: 8px 0;
+  border-bottom: 1px dashed #ccc;
+}
+
+/* 회색 처리: 삭제된 댓글 */
+.deleted {
+  color: gray;
+  font-style: italic;
+}
+
 </style>

--- a/src/main/java/study/multiproject/api/controller/comment/CommentController.java
+++ b/src/main/java/study/multiproject/api/controller/comment/CommentController.java
@@ -1,0 +1,59 @@
+package study.multiproject.api.controller.comment;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import study.multiproject.api.common.ApiResponse;
+import study.multiproject.api.controller.comment.converter.CommentCreateRequestConverter;
+import study.multiproject.api.controller.comment.converter.CommentPageRequestConverter;
+import study.multiproject.api.controller.comment.request.CommentCreateRequest;
+import study.multiproject.api.controller.comment.request.CommentPageRequest;
+import study.multiproject.api.service.comment.CommentService;
+import study.multiproject.api.service.comment.response.CommentPageResponse;
+import study.multiproject.api.service.comment.response.CommentResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+    private final CommentCreateRequestConverter commentCreateRequestConverter;
+    private final CommentPageRequestConverter commentPageRequestConverter;
+
+    /**
+     * 댓글 생성
+     */
+    @PostMapping("/comments")
+    public ApiResponse<CommentResponse> create(@RequestBody CommentCreateRequest request) {
+        return ApiResponse.success(commentService.create(commentCreateRequestConverter.toServiceRequest(request)));
+    }
+
+    /**
+     * 댓글 조회
+     */
+    @GetMapping("/comments/{commentId}")
+    public ApiResponse<CommentResponse> get(@PathVariable Long commentId) {
+        return ApiResponse.success(commentService.read(commentId));
+    }
+
+    /**
+     * 댓글 삭제
+     */
+    @DeleteMapping("/comments/{commentId}")
+    public ApiResponse<Void> delete(@PathVariable Long commentId) {
+        commentService.delete(commentId);
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 댓글 목록 조회
+     */
+    @GetMapping("/comments")
+    public ApiResponse<CommentPageResponse> readAll(@Valid CommentPageRequest request) {
+        return ApiResponse.success(commentService.readAll(commentPageRequestConverter.toServiceRequest(request)));
+    }
+}

--- a/src/main/java/study/multiproject/api/controller/comment/converter/CommentCreateRequestConverter.java
+++ b/src/main/java/study/multiproject/api/controller/comment/converter/CommentCreateRequestConverter.java
@@ -1,0 +1,15 @@
+package study.multiproject.api.controller.comment.converter;
+
+import org.springframework.stereotype.Component;
+import study.multiproject.api.controller.comment.request.CommentCreateRequest;
+import study.multiproject.api.service.comment.request.CommentCreateServiceRequest;
+
+@Component
+public class CommentCreateRequestConverter {
+
+    public CommentCreateServiceRequest toServiceRequest(CommentCreateRequest request) {
+        return new CommentCreateServiceRequest(request.postId(), request.nickname(),
+            request.content(), request.parentCommentId(), request.writerId());
+    }
+
+}

--- a/src/main/java/study/multiproject/api/controller/comment/converter/CommentPageRequestConverter.java
+++ b/src/main/java/study/multiproject/api/controller/comment/converter/CommentPageRequestConverter.java
@@ -1,0 +1,14 @@
+package study.multiproject.api.controller.comment.converter;
+
+import org.springframework.stereotype.Component;
+import study.multiproject.api.controller.comment.request.CommentPageRequest;
+import study.multiproject.api.service.comment.request.CommentPageServiceRequest;
+
+@Component
+public class CommentPageRequestConverter {
+
+    public CommentPageServiceRequest toServiceRequest(CommentPageRequest request) {
+        return new CommentPageServiceRequest(request.getPageable(), request.postId());
+    }
+
+}

--- a/src/main/java/study/multiproject/api/controller/comment/request/CommentCreateRequest.java
+++ b/src/main/java/study/multiproject/api/controller/comment/request/CommentCreateRequest.java
@@ -1,0 +1,10 @@
+package study.multiproject.api.controller.comment.request;
+
+public record CommentCreateRequest(
+    Long postId,
+    String nickname,
+    String content,
+    Long parentCommentId,
+    Long writerId) {
+
+}

--- a/src/main/java/study/multiproject/api/controller/comment/request/CommentPageRequest.java
+++ b/src/main/java/study/multiproject/api/controller/comment/request/CommentPageRequest.java
@@ -1,0 +1,17 @@
+package study.multiproject.api.controller.comment.request;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public record CommentPageRequest(
+    @Min(value = 1, message = "페이지 번호가 잘못되었습니다.") int page,
+    @Min(value = 1, message = "사이즈 번호가 잘못되었습니다.") int size,
+    Long postId
+) {
+
+    public Pageable getPageable() {
+        return PageRequest.of(page - 1, size, Sort.by("id").descending());
+    }
+}

--- a/src/main/java/study/multiproject/api/error/exception/ResponseCode.java
+++ b/src/main/java/study/multiproject/api/error/exception/ResponseCode.java
@@ -19,6 +19,11 @@ public enum ResponseCode {
     FILE_LOAD_ERROR(500, "F003", "파일을 읽을 수 없습니다."),
     FILE_CONVERSION_ERROR(500, "F004", "파일 변환에 실패했습니다."),
     FILE_SIZE_ERROR(400, "F005", "파일 크기 확인에 실패했습니다."),
+
+    // COMMENT
+
+    NOT_FOUND_COMMENT(404, "C001", "존재하지 않는 댓글입니다."),
+    NOT_FOUND_PARENT_COMMENT(404, "C002", "부모 댓글이 존재하지 않습니다."),
     ;
 
     private final int status;

--- a/src/main/java/study/multiproject/api/service/comment/CommentService.java
+++ b/src/main/java/study/multiproject/api/service/comment/CommentService.java
@@ -1,0 +1,107 @@
+package study.multiproject.api.service.comment;
+
+import static java.util.function.Predicate.not;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import study.multiproject.api.service.comment.request.CommentCreateServiceRequest;
+import study.multiproject.api.service.comment.request.CommentPageServiceRequest;
+import study.multiproject.api.service.comment.response.CommentPageResponse;
+import study.multiproject.api.service.comment.response.CommentResponse;
+import study.multiproject.api.service.exception.CommentNotFoundException;
+import study.multiproject.api.service.exception.ParentCommentNotFoundException;
+import study.multiproject.domain.comment.Comment;
+import study.multiproject.domain.comment.CommentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+
+    /**
+     * 댓글 생성
+     */
+    @Transactional
+    public CommentResponse create(CommentCreateServiceRequest request) {
+        Comment parent = findParentComment(request.parentCommentId());
+        Comment comment = commentRepository.save(request.toEntity(parent));
+        return new CommentResponse(comment);
+    }
+
+    /**
+     * 댓글 조회
+     */
+    public CommentResponse read(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                              .orElseThrow(CommentNotFoundException::new);
+        return new CommentResponse(comment);
+    }
+
+    /**
+     * 댓글 삭제
+     */
+    @Transactional
+    public void delete(Long commentId) {
+        commentRepository.findById(commentId)
+            .filter(not(Comment::isDeleted))
+            .ifPresent(comment -> {
+                if (hasChildren(comment)) { // 자식 댓글이 있는 경우 삭제 처리
+                    comment.delete();
+                } else { // 자식 댓글이 없는 경우 재귀적 삭제
+                    recursionDelete(comment);
+                }
+            });
+    }
+
+    /**
+     * 댓글 목록 조회
+     */
+    public CommentPageResponse readAll(CommentPageServiceRequest request) {
+        List<Comment> comments = commentRepository.findAll(
+            request.postId(),
+            request.pageable().getOffset(),
+            request.pageable().getPageSize()
+        );
+        List<CommentResponse> commentResponses = comments.stream()
+                                                     .map(CommentResponse::new)
+                                                     .toList();
+        Long totalComments = commentRepository.count(request.postId());
+        return new CommentPageResponse(commentResponses, totalComments);
+    }
+
+    /**
+     * 댓글 재귀적 삭제
+     */
+    private void recursionDelete(Comment comment) {
+        commentRepository.delete(comment);
+        if (!comment.isRoot()) {
+            commentRepository.findById(comment.getParentCommentId())
+                .filter(Comment::isDeleted)
+                .filter(not(this::hasChildren))
+                .ifPresent(this::recursionDelete);
+        }
+    }
+
+    /**
+     * 댓글의 자식 댓글이 있는지 확인
+     */
+    private boolean hasChildren(Comment comment) {
+        return commentRepository.countBy(comment.getPostId(), comment.getId(), 2L) == 2;
+    }
+
+    /**
+     * 부모 댓글 조회
+     */
+    private Comment findParentComment(Long parentCommentId) {
+        if (parentCommentId == null) {
+            return null;
+        }
+        return commentRepository.findById(parentCommentId)
+                   .filter(not(Comment::isDeleted))
+                   .filter(Comment::isRoot)
+                   .orElseThrow(ParentCommentNotFoundException::new);
+    }
+}

--- a/src/main/java/study/multiproject/api/service/comment/request/CommentCreateServiceRequest.java
+++ b/src/main/java/study/multiproject/api/service/comment/request/CommentCreateServiceRequest.java
@@ -1,0 +1,18 @@
+package study.multiproject.api.service.comment.request;
+
+import study.multiproject.domain.comment.Comment;
+
+public record CommentCreateServiceRequest(Long postId, String nickname, String content,
+                                          Long parentCommentId, Long writerId) {
+
+    public Comment toEntity(Comment parentComment) {
+        return Comment.builder()
+                   .postId(postId)
+                   .nickname(nickname)
+                   .content(content)
+                   .parentCommentId(
+                       parentComment == null ? null : parentComment.getId())
+                   .writerId(writerId)
+                   .build();
+    }
+}

--- a/src/main/java/study/multiproject/api/service/comment/request/CommentPageServiceRequest.java
+++ b/src/main/java/study/multiproject/api/service/comment/request/CommentPageServiceRequest.java
@@ -1,0 +1,9 @@
+package study.multiproject.api.service.comment.request;
+
+import org.springframework.data.domain.Pageable;
+
+public record CommentPageServiceRequest(
+    Pageable pageable,
+    Long postId) {
+
+}

--- a/src/main/java/study/multiproject/api/service/comment/response/CommentPageResponse.java
+++ b/src/main/java/study/multiproject/api/service/comment/response/CommentPageResponse.java
@@ -1,0 +1,7 @@
+package study.multiproject.api.service.comment.response;
+
+import java.util.List;
+
+public record CommentPageResponse(List<CommentResponse> comment, Long commentCount) {
+
+}

--- a/src/main/java/study/multiproject/api/service/comment/response/CommentResponse.java
+++ b/src/main/java/study/multiproject/api/service/comment/response/CommentResponse.java
@@ -1,0 +1,15 @@
+package study.multiproject.api.service.comment.response;
+
+import java.time.LocalDateTime;
+import study.multiproject.domain.comment.Comment;
+
+public record CommentResponse(Long id, String nickname, String comment, Long parentCommentId,
+                              Long postId, Long writerId, boolean deleted,
+                              LocalDateTime createdAt) {
+
+    public CommentResponse(Comment comment) {
+        this(comment.getId(), comment.getNickname(), comment.getContent(),
+            comment.getParentCommentId(), comment.getPostId(), comment.getWriterId(),
+            comment.isDeleted(), comment.getCreatedAt());
+    }
+}

--- a/src/main/java/study/multiproject/api/service/exception/CommentNotFoundException.java
+++ b/src/main/java/study/multiproject/api/service/exception/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package study.multiproject.api.service.exception;
+
+import study.multiproject.api.error.exception.BaseException;
+import study.multiproject.api.error.exception.ResponseCode;
+
+public class CommentNotFoundException extends BaseException {
+
+    public CommentNotFoundException() {
+        super(ResponseCode.NOT_FOUND_COMMENT);
+    }
+}

--- a/src/main/java/study/multiproject/api/service/exception/ParentCommentNotFoundException.java
+++ b/src/main/java/study/multiproject/api/service/exception/ParentCommentNotFoundException.java
@@ -1,0 +1,10 @@
+package study.multiproject.api.service.exception;
+
+import study.multiproject.api.error.exception.BaseException;
+import study.multiproject.api.error.exception.ResponseCode;
+
+public class ParentCommentNotFoundException extends BaseException {
+    public ParentCommentNotFoundException() {
+        super(ResponseCode.NOT_FOUND_COMMENT);
+    }
+}

--- a/src/main/java/study/multiproject/domain/comment/Comment.java
+++ b/src/main/java/study/multiproject/domain/comment/Comment.java
@@ -1,0 +1,89 @@
+package study.multiproject.domain.comment;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PostPersist;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment {
+
+    /**
+     * 식별자
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 닉네임
+     */
+    private String nickname;
+
+    /**
+     * 댓글 내용
+     */
+    private String content;
+
+    /**
+     * 부모 댓글 아이디
+     */
+    private Long parentCommentId;
+
+    /**
+     * 게시글 아이디
+     */
+    private Long postId;
+
+    /**
+     * 작성자 아이디
+     */
+    private Long writerId;
+
+    /**
+     * 삭제 여부
+     */
+    private boolean deleted;
+
+    /**
+     * 생성일시
+     */
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Comment(Long id, String nickname, String content, Long parentCommentId, Long postId, Long writerId) {
+        this.id = id;
+        this.nickname = nickname;
+        this.content = content;
+        this.parentCommentId = parentCommentId;
+        this.postId = postId;
+        this.writerId = writerId;
+        this.deleted = false;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PostPersist
+    public void setParentCommentId() {
+        if (this.parentCommentId == null) {
+            this.parentCommentId = this.id;
+        }
+    }
+
+    public boolean isRoot() {
+        return parentCommentId.longValue() == id;
+    }
+
+    public void delete() {
+        deleted = true;
+    }
+}

--- a/src/main/java/study/multiproject/domain/comment/CommentRepository.java
+++ b/src/main/java/study/multiproject/domain/comment/CommentRepository.java
@@ -1,0 +1,54 @@
+package study.multiproject.domain.comment;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query(
+        value = "select count(*) from (" +
+                    " select id from comment " +
+                    " where post_id = :postId and parent_comment_id = :parentCommentId " +
+                    " limit :limit" +
+                    ") t",
+        nativeQuery = true
+    )
+    Long countBy(
+        @Param("postId") Long postId,
+        @Param("parentCommentId") Long parentCommentId,
+        @Param("limit") Long limit
+    );
+
+    @Query(
+        value =
+            "SELECT c.id, c.nickname, c.content, c.parent_comment_id, c.post_id, c.writer_id, c.deleted, c.created_at "
+                +
+                "FROM ( " +
+                "  SELECT id FROM comment " +
+                "  WHERE post_id = :postId " +
+                "  ORDER BY parent_comment_id ASC, id ASC " +
+                "  LIMIT :limit OFFSET :offset " +
+                ") t " +
+                "JOIN comment c ON t.id = c.id",
+        nativeQuery = true
+    )
+    List<Comment> findAll(
+        @Param("postId") Long postId,
+        @Param("offset") Long offset,
+        @Param("limit") int limit
+    );
+
+    @Query(
+        value = "select count(*) from (" +
+                    " select id from comment where post_id = :postId " +
+                    ") t",
+        nativeQuery = true
+    )
+    Long count(
+        @Param("postId") Long postId
+    );
+}


### PR DESCRIPTION
1. 이슈 번호 : [#15 ]
2. 작업 내용
- 게시글 댓글 작성
- 게시글 댓글 삭제
- 게시글 댓글 목록 조회
  - 댓글 오래된순으로 정렬한다. 
  - 댓글은 대댓글을 달 수 있다. (최대 2depth)
  - 상위 댓글을 공유하는 하위 댓글은 생성 시간순 정렬
- 상위 댓글은 항상 하위 댓글보다 먼저 생성

### 댓글 삭제 전략

- 하위 댓글 X

<img width="521" alt="image" src="https://github.com/user-attachments/assets/e24c5f39-be00-4e01-b55e-30438d4cf85d" />

- 하위 댓글 O

<img width="468" alt="image" src="https://github.com/user-attachments/assets/784fe1de-b073-4aef-83e3-4c8a940b0ccb" />

- 재귀적 삭제
하위 댓글 삭제시 상위 댓글이 삭제 표시되었다면 재귀적 삭제

https://github.com/user-attachments/assets/18010350-2420-4088-9f1e-9513f8dbfe81



