### PR TITLE
[#59] Circuitbreaker로 조회수 백업시스템 구현

### DIFF
--- a/board-server/build.gradle
+++ b/board-server/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation "io.github.resilience4j:resilience4j-spring-boot3:2.2.0"
+    implementation "org.springframework.boot:spring-boot-starter-actuator"
+    implementation "org.springframework.boot:spring-boot-starter-aop"
     implementation 'com.github.codemonstur:embedded-redis:1.4.3'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/board-server/src/main/java/study/multiproject/global/config/CircuitBreakerConfig.java
+++ b/board-server/src/main/java/study/multiproject/global/config/CircuitBreakerConfig.java
@@ -1,0 +1,39 @@
+package study.multiproject.global.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.core.registry.EntryAddedEvent;
+import io.github.resilience4j.core.registry.EntryRemovedEvent;
+import io.github.resilience4j.core.registry.EntryReplacedEvent;
+import io.github.resilience4j.core.registry.RegistryEventConsumer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+public class CircuitBreakerConfig {
+
+    @Bean
+    public RegistryEventConsumer<CircuitBreaker> myRegistryEventConsumer() {
+
+        return new RegistryEventConsumer<CircuitBreaker>() {
+            @Override
+            public void onEntryAddedEvent(EntryAddedEvent<CircuitBreaker> entryAddedEvent) {
+                log.info("RegistryEventConsumer.onEntryAddedEvent");
+                entryAddedEvent.getAddedEntry().getEventPublisher().onEvent(event -> log.info(event.toString()));
+                entryAddedEvent.getAddedEntry().getEventPublisher().onFailureRateExceeded(event -> log.info("{}", event.getEventType()));
+
+            }
+
+            @Override
+            public void onEntryRemovedEvent(EntryRemovedEvent<CircuitBreaker> entryRemoveEvent) {
+                log.info("RegistryEventConsumer.onEntryRemovedEvent");
+            }
+
+            @Override
+            public void onEntryReplacedEvent(EntryReplacedEvent<CircuitBreaker> entryReplacedEvent) {
+                log.info("RegistryEventConsumer.onEntryReplacedEvent");
+            }
+        };
+    }
+}

--- a/board-server/src/main/java/study/multiproject/post/application/LocalBufferFlusher.java
+++ b/board-server/src/main/java/study/multiproject/post/application/LocalBufferFlusher.java
@@ -1,0 +1,34 @@
+package study.multiproject.post.application;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import study.multiproject.post.dao.PostRepository;
+
+@Service
+@RequiredArgsConstructor
+public class LocalBufferFlusher {
+
+    private final LocalViewBuffer buffer;
+    private final PostRepository postRepository;
+
+    /**
+     * 로컬 버퍼에 저장된 게시글 조회수가 있다면 데이터베이스에 반영한다.
+     */
+    @Scheduled(fixedRate = 60_000)  // 1분마다 실행
+    @Transactional
+    public void flushToDb() {
+        Map<Long, Long> deltaMap = buffer.drain();
+        if (deltaMap.isEmpty()) {
+            return;
+        }
+
+        deltaMap.forEach((postId, delta) -> {
+            if (delta != null && delta > 0) {
+                postRepository.incrementViewCount(postId, delta); // 게시글 조회수 증가
+            }
+        });
+    }
+}

--- a/board-server/src/main/java/study/multiproject/post/application/LocalViewBuffer.java
+++ b/board-server/src/main/java/study/multiproject/post/application/LocalViewBuffer.java
@@ -1,0 +1,28 @@
+package study.multiproject.post.application;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocalViewBuffer {
+    private final ConcurrentHashMap<Long, LongAdder> map = new ConcurrentHashMap<>();
+
+    /**
+     * 로컬 버퍼에 게시글 조회수 증가
+     */
+    public void increase(long postId) {
+        map.computeIfAbsent(postId, k -> new LongAdder()).increment();
+    }
+
+    /**
+     * 로컬 버퍼에 저장된 게시글 조회수 스냅샷을 반환하고 초기화
+     */
+    public Map<Long, Long> drain() {
+        Map<Long, Long> snap = new HashMap<>();
+        map.forEach((k, adder) -> snap.put(k, adder.sumThenReset()));
+        return snap;
+    }
+}

--- a/board-server/src/main/java/study/multiproject/post/application/PostHitsCircuitService.java
+++ b/board-server/src/main/java/study/multiproject/post/application/PostHitsCircuitService.java
@@ -1,0 +1,36 @@
+package study.multiproject.post.application;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostHitsCircuitService {
+
+    private final PostHitsService postHitsService;
+    private final LocalViewBuffer localViewBuffer;
+
+    /**
+     * 방문자 중복 체크 후 최초 방문이면 조회수 증가 + 방문자 등록
+     * Redis 장애/지연 시 fallback으로 스킵
+     */
+    @CircuitBreaker(name = "CircuitBreakerConfig", fallbackMethod = "firstVisitFallback")
+    public void visitRedis(String visitorId, long postId) {
+        if (!postHitsService.isExistInSet(visitorId, postId)) {
+            postHitsService.increaseData("viewCount_post_" + postId);
+            postHitsService.addToSet(visitorId, postId);
+        }
+    }
+
+    /**
+     * 주요 서비스에서 Redis 장애/지연 시 호출되는 fallback 메서드
+     */
+    public void firstVisitFallback(String visitorId, long postId, Throwable t) {
+        localViewBuffer.increase(postId);
+        log.warn("Redis unavailable -> buffered locally. visitorId={}, postId={}, cause={}",
+            visitorId, postId, (t != null ? t.toString() : "n/a"));
+    }
+}

--- a/board-server/src/main/java/study/multiproject/post/application/PostHitsScheduler.java
+++ b/board-server/src/main/java/study/multiproject/post/application/PostHitsScheduler.java
@@ -4,6 +4,7 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import study.multiproject.post.exception.PostNotFoundException;
 import study.multiproject.post.domain.Post;
 import study.multiproject.post.dao.PostRepository;
@@ -18,6 +19,7 @@ public class PostHitsScheduler {
     /**
      * 1분마다 Redis에 저장된 조회수를 데이터베이스에 저장
      */
+    @Transactional
     @Scheduled(fixedRate = 60000)
     public void saveHitsToDatabase() {
         Set<String> keys = postHitsService.getAllKeys();

--- a/board-server/src/main/java/study/multiproject/post/application/PostService.java
+++ b/board-server/src/main/java/study/multiproject/post/application/PostService.java
@@ -33,7 +33,7 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final HashtagRepository hashtagRepository;
-    private final PostHitsService postHitsService;
+    private final PostHitsCircuitService postHitsCircuitService;
     private final CategoryService categoryService;
     private final FileService fileService;
     private final UserService userService;
@@ -62,10 +62,8 @@ public class PostService {
             throw new SecretPostException();
         }
 
-        if (!postHitsService.isExistInSet(visitorId, post.getId())) {
-            postHitsService.increaseData("viewCount_post_" + post.getId());
-            postHitsService.addToSet(visitorId, post.getId());
-        }
+        postHitsCircuitService.visitRedis(visitorId, post.getId());
+
         return new PostResponse(post, userId);
     }
 

--- a/board-server/src/main/java/study/multiproject/post/dao/PostRepository.java
+++ b/board-server/src/main/java/study/multiproject/post/dao/PostRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import study.multiproject.post.domain.Post;
@@ -22,4 +23,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findPostWithHashtags(@Param("postId") Long postId);
 
     List<Post> findTop20ByOrderByCreatedAtDesc();
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + :delta WHERE p.id = :postId")
+    void incrementViewCount(@Param("postId") Long postId, @Param("delta") long delta);
 }

--- a/board-server/src/main/resources/application-dev.yml
+++ b/board-server/src/main/resources/application-dev.yml
@@ -20,3 +20,39 @@ spring:
       hibernate.format_sql: true
       hibernate.show_sql: true
       hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
+
+resilience4j.circuitbreaker:
+  configs:
+    default:
+      slidingWindowType: COUNT_BASED
+      minimumNumberOfCalls: 7                                   # 최소 7번까지는 무조건 CLOSE로 가정하고 호출한다.
+      slidingWindowSize: 10                                     # (minimumNumberOfCalls 이후로는) 10개의 요청을 기준으로 판단한다.
+      waitDurationInOpenState: 10s                              # OPEN 상태에서 HALF_OPEN으로 가려면 얼마나 기다릴 것인가?
+
+      failureRateThreshold: 40                                  # slidingWindowSize 중 몇 %가 recordException이면 OPEN으로 만들 것인가?
+
+      slowCallDurationThreshold: 3000                           # 몇 ms 동안 요청이 처리되지 않으면 실패로 간주할 것인가?
+      slowCallRateThreshold: 60                                 # slidingWindowSize 중 몇 %가 slowCall이면 OPEN으로 만들 것인가?
+
+      permittedNumberOfCallsInHalfOpenState: 5                  # HALF_OPEN 상태에서 5번까지는 CLOSE로 가기위해 호출한다.
+      automaticTransitionFromOpenToHalfOpenEnabled: true        # OPEN 상태에서 자동으로 HALF_OPEN으로 갈 것인가?
+
+      eventConsumerBufferSize: 10                               # actuator를 위한 이벤트 버퍼 사이즈
+
+      recordExceptions: # Redis/인프라 관련 예외들을 기록한다.
+        - io.lettuce.core.RedisCommandTimeoutException
+        - io.lettuce.core.RedisConnectionException
+        - io.lettuce.core.RedisException
+        - org.springframework.data.redis.RedisConnectionFailureException
+        - org.springframework.data.redis.RedisSystemException
+        - java.net.SocketTimeoutException
+        - java.net.ConnectException
+        - java.net.UnknownHostException
+
+      ignoreExceptions: # 도메인/검증/비즈니스 예외는 무시 (서킷에 영향 X)
+        - study.multiproject.post.exception.PostNotFoundException
+        - study.multiproject.post.exception.SecretPostException
+        - java.lang.IllegalArgumentException
+  instances:
+    CircuitBreakerConfig:
+      baseConfig: default


### PR DESCRIPTION
1. 이슈 번호 : [#59 ]
2. 작업 내용
- 운영중인 Redis에 장애가 생긴다면 다른 서비스들에게 영향을 미칠 수 있음.
- 아래의 초점을 맞춰 조회 수 관련 설계
  - 가용성 : Redis 장애/지연 시에도 정상 동작한다.
  - 유실 최소화 : 장애 구간의 카운트는 최대한 보전한다.

- CLOSED 상태
<img width="669" height="396" alt="image" src="https://github.com/user-attachments/assets/2ac2c33e-ba97-4b5b-9a22-7d53c8959193" />

- OPEN 상태
<img width="666" height="391" alt="image" src="https://github.com/user-attachments/assets/d867bfbb-0a56-4248-88d2-41c55e4c3319" />

참고 : https://systemdata.tistory.com/120